### PR TITLE
Don't hot reload bots when the match starts. Undo score workaround.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,8 @@ venv.bak/
 
 # IDE
 .idea
+*.iml
+.vscode
 
 # Credentials and tokens
 sheets-api-token.pickle

--- a/autoleague/match_exercise.py
+++ b/autoleague/match_exercise.py
@@ -51,22 +51,9 @@ class MatchGrader(Grader):
             return None
 
     def fetch_match_score(self, packet: GameTickPacket):
-        # There's a bug in the framework here so we have to be careful.
-        # packet.teams[i].score can be wrong if the team did not score any goals. It will be the score of the previous
-        # match. We can instead sum the goals of the players, but this will miss goals where none from a team touched
-        # the ball. E.g. "BLUE scored"
-        # So instead we check if summed score is not 0. If so, packet.teams[i].score must have been reset correctly,
-        # and we can use that without problems. If summed score is 0, we can't know anything for sure...
-        # But let's assume no match solely has non-touch goals. Then summed score is correct.
-
-        blue_goals = sum(packet.game_cars[i].score_info.goals for i in range(packet.num_cars) if packet.game_cars[i].team == 0)
-        orange_goals = sum(packet.game_cars[i].score_info.goals for i in range(packet.num_cars) if packet.game_cars[i].team == 1)
-        blue_goals = packet.teams[0].score if blue_goals > 0 else blue_goals
-        orange_goals = packet.teams[1].score if orange_goals > 0 else orange_goals
-
         self.match_result = MatchResult(
-            blue_goals=blue_goals,
-            orange_goals=orange_goals,
+            blue_goals=packet.teams[0].score,
+            orange_goals=packet.teams[1].score,
             player_scores={
                 fmt_bot_name(packet.game_cars[i].name): PlayerScore(
                     points=packet.game_cars[i].score_info.score,

--- a/autoleague/replays.py
+++ b/autoleague/replays.py
@@ -87,6 +87,11 @@ class ReplayMonitor(Metric):
 
 
 def get_replay_dir() -> Path:
-    replay_dir = Path.home() / 'documents' / 'My Games' / 'Rocket League' / 'TAGame' / 'Demos'
-    assert replay_dir.exists()
-    return replay_dir
+    possibilities = [
+        Path.home() / 'documents' / 'My Games' / 'Rocket League' / 'TAGame' / 'Demos',
+        Path.home() / 'OneDrive' / 'documents' / 'My Games' / 'Rocket League' / 'TAGame' / 'Demos'
+    ]
+    for path in possibilities:
+        if path.exists():
+            return path
+    raise FileExistsError("Could not find replay directory!")


### PR DESCRIPTION
When testing with RLBot version 1.55.6, I found that my fix for the team score bug was effective.

Threw in a bonus fix while I was in there.