### PR TITLE
Balancing the number of games each bot gets to play in a session

### DIFF
--- a/autoleague/match_maker.py
+++ b/autoleague/match_maker.py
@@ -24,7 +24,6 @@ class TicketSystem:
     def __init__(self):
         self.tickets: Dict[BotID, float] = {}
         self.new_bot_ticket_count = 4.0
-        self.ticket_increase_rate = 2.0
         self.session_game_counts: Dict[BotID, int] = {}
 
     def ensure(self, bots: Iterable[BotID]):
@@ -91,8 +90,16 @@ class TicketSystem:
                 self.session_game_counts[bot] += 1
             else:
                 # Increase their tickets
+
+                # Tickets increase faster if the bot is lagging behind on the number of games played.
                 games_deficit = max_game_count - self.session_game_counts[bot]
-                self.tickets[bot] *= (self.ticket_increase_rate + games_deficit)
+
+                # Tickets also multiply a little even if the bot has played more games than any other.
+                # Decrease this number toward 1.0 if you want to prioritize a balanced number of games played.
+                # Increase it if you want more randomness, and priority for bots who haven't played recently.
+                base_ticket_multiplier = 1.2
+
+                self.tickets[bot] *= (base_ticket_multiplier + games_deficit)
 
     def save(self, ld: LeagueDir, time_stamp: str):
         with open(ld.tickets / f"{time_stamp}_tickets.json", 'w') as f:

--- a/test/match_maker_test.py
+++ b/test/match_maker_test.py
@@ -58,7 +58,11 @@ class TestMatchMaker(unittest.TestCase):
         for i in range(19):
             MatchMaker.decide_on_players_2(bot_ids, rank_sys, ticket_sys)
         game_counts = list(ticket_sys.session_game_counts.values())
+        print(ticket_sys.session_game_counts)
         print(f'Game count std dev: {numpy.std(game_counts)}, max: {max(game_counts)} min: {min(game_counts)} avg: {numpy.mean(game_counts)}')
+        for i in range(5):
+            print(f'Num with {i}: {game_counts.count(i)}')
+        # Before the equity changes, there are ~12 bots who have only played once. Now it's usually 1 or 2.
 
 
 if __name__ == '__main__':

--- a/test/match_maker_test.py
+++ b/test/match_maker_test.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+import numpy
 from pathlib import Path
 from typing import Tuple, List
 
@@ -48,7 +49,16 @@ class TestMatchMaker(unittest.TestCase):
             quality = get_trueskill_quality(players, rank_sys)
             quality_sum += quality
         average = quality_sum / NUM_ITERATIONS
-        print(f'New average quality: {average}')  # 0.453
+        print(f'New average quality: {average}')  # 0.449
+
+    def test_gamecount_equity(self):
+        rank_sys = RankingSystem.read(RESOURCES_FOLDER / '20210925212802_rankings.json')
+        ticket_sys = TicketSystem.read(RESOURCES_FOLDER / '20210925212802_tickets.json', LeagueSettings())
+        bot_ids = rank_sys.ratings.keys()
+        for i in range(19):
+            MatchMaker.decide_on_players_2(bot_ids, rank_sys, ticket_sys)
+        game_counts = list(ticket_sys.session_game_counts.values())
+        print(f'Game count std dev: {numpy.std(game_counts)}, max: {max(game_counts)} min: {min(game_counts)} avg: {numpy.mean(game_counts)}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
After this change, bots that have played fewer games in the current session will have their ticket growth significantly boosted. This avoids situations where one bot has played 5 times in a stream and another has played only once.

This reduces randomness and compromises match quality a little bit, but not much.

I have not yet tested TicketSystem.load() or the overlay, but I suspect they'll work fine.